### PR TITLE
Improve last-batch-for-period condition check

### DIFF
--- a/src/soccer_monitoring.cpp
+++ b/src/soccer_monitoring.cpp
@@ -40,9 +40,8 @@ void run_game_monitoring(int time_units, double maximum_distance,
 
   visualizer.draw();
   auto t1 = std::chrono::steady_clock::now();
-  for (auto const &batch : fetcher) {
+  for (auto const &[batch, is_period_last_batch] : fetcher) {
     // Check if batch returned because time_units seconds are elapsed
-    auto is_period_last_batch = !batch.empty() && batch.size() < batch_size;
     stats.batch_stats(batch, is_period_last_batch);
 
     if (is_period_last_batch) {
@@ -95,9 +94,8 @@ void run_game_monitoring(int time_units, double maximum_distance,
                                     time_units, batch_size, context};
   auto stats = game::GameStatistics{maximum_distance, context};
 
-  for (auto const &batch : fetcher) {
+  for (auto const &[batch, is_period_last_batch] : fetcher) {
     // Check if batch returned because time_units seconds are elapsed
-    auto is_period_last_batch = !batch.empty() && batch.size() < batch_size;
     stats.batch_stats(batch, is_period_last_batch);
 
     if (is_period_last_batch) {

--- a/test/test_event_fetcher.cpp
+++ b/test/test_event_fetcher.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Test Event Fetcher", "[event_fetcher]") {
         game::EventFetcher{game_data_start_10_50, game::string_stream{},
                            time_units, batch_size, context};
 
-    const auto &first_batch = fetcher.parse_batch();
+    const auto &first_batch = fetcher.parse_batch().first.get();
 
     // Batch has BATCH_SIZE size
     REQUIRE(first_batch.size() == batch_size);

--- a/test/test_game_statistics.cpp
+++ b/test/test_game_statistics.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Test batch_stats computation") {
     auto stats =
         game::GameStatistics{game::GameStatistics::infinite_distance, context};
 
-    for (auto const &batch : fetcher) {
+    for (auto const &[batch, is_period_last_batch] : fetcher) {
       stats.batch_stats(batch, false);
       print_partial_stats(stats, context);
       fmt::print("\n");

--- a/test/test_visualizer.cpp
+++ b/test/test_visualizer.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Test Visualizer") {
     auto visualizer = game::Visualizer{players, teams, time_units};
     visualizer.draw();
 
-    for (auto const &batch : fetcher) {
+    for (auto const &[batch, is_period_last_batch] : fetcher) {
       stats.batch_stats(batch, false);
       auto partials = stats.accumulated_stats();
       visualizer.update_stats(partials);


### PR DESCRIPTION
Before, check was performed outside of EventFetcher code, without enough information. Also it caused a bug when program was run with --batch-size = 1. Now checks are performed inside parse_batch().

Signed-off-by: Leonardo Arcari <lippol94@gmail.com>