### PR TITLE
Add significant performance improvement by changing line parser

### DIFF
--- a/include/event_fetcher.hpp
+++ b/include/event_fetcher.hpp
@@ -30,7 +30,6 @@ class EventFetcher {
 public:
   friend class details::event_fetcher_iterator;
   using iterator = details::event_fetcher_iterator;
-
   /**
    * @brief Construct a new EventFetcher object with given batch size.
    *
@@ -43,7 +42,6 @@ public:
   template <typename Stream>
   EventFetcher(std::string const &, Stream, int time_units,
                std::size_t batch_size, Context &context);
-
   /**
    * @brief Parses next in-game PositionEvent. If next event is an
    * InterruptionEvent, PositionEvents are skipped until a ResumEvent is found.
@@ -52,7 +50,6 @@ public:
    * @return next in-game PositionEvent
    */
   PositionEvent parse_next_event();
-
   /**
    * @brief Parses next in-game batch of PositionEvent.
    * If batch_size PositionEvent are parsed, it returns a batch of batch_size
@@ -64,10 +61,21 @@ public:
    */
   std::pair<std::reference_wrapper<const std::vector<PositionEvent>>, bool>
   parse_batch();
-
+  /**
+   * Tests whether an event is valid to be added to a batch, i.e. its timestamp
+   * is within the first half or the second half of the game.
+   *
+   * @param event the PositionEvent to test
+   * @return true if valid, false otherwise
+   */
   bool is_valid_event(PositionEvent const &event) const;
-
+  /**
+   * @return an iterator to the first batch of PositionEvents
+   */
   iterator begin();
+  /**
+   * @return an iterator to the batch following the last one
+   */
   iterator end();
 
 private:
@@ -124,6 +132,28 @@ struct Dataset {
   // =------------------------------------------=
   static constexpr auto gi_re_event_id_idx = 1;
   static constexpr auto gi_re_timestamp_idx = 2;
+
+  /**
+   * Custom parser token index for event type (SE or GI)
+   */
+  static constexpr std::size_t event_type_idx = 0;
+
+  // =------------------------------------------=
+  //       SE custom parser token indices
+  // =------------------------------------------=
+
+  static constexpr std::size_t se_sid_idx = 1;
+  static constexpr std::size_t se_timestamp_idx = 2;
+  static constexpr std::size_t se_x_idx = 3;
+  static constexpr std::size_t se_y_idx = 4;
+  static constexpr std::size_t se_z_idx = 5;
+
+  // =------------------------------------------=
+  //       GI custom parser token indices
+  // =------------------------------------------=
+
+  static constexpr std::size_t gi_event_id_idx = 1;
+  static constexpr std::size_t gi_timestamp_idx = 4;
 };
 
 /**
@@ -172,6 +202,10 @@ private:
   std::string line;
 };
 
+
+struct parser_regex {};
+struct parser_custom{};
+
 /**
  * @brief Parse a single event line into an event.
  *
@@ -182,8 +216,9 @@ private:
  * @return The parsed event as a std::variant of PositionEvent,
  * InterruptionEvent or ResumeEvent in case @p line is a known event type.
  */
+template <typename Strategy = game::parser_regex>
 std::variant<std::monostate, PositionEvent, InterruptionEvent, ResumeEvent>
-parse_event_line(std::string const &line);
+parse_event_line(std::string const &line, Strategy = Strategy{});
 } // namespace game
 
 #endif

--- a/include/game_statistics.hpp
+++ b/include/game_statistics.hpp
@@ -26,7 +26,6 @@ public:
    * Infinite distance value.
    */
   static constexpr auto infinite_distance = std::numeric_limits<double>::max();
-
   /**
    * Constructs a GameStatistics object.
    *
@@ -38,7 +37,6 @@ public:
       : maximum_distance{maximum_distance}, context{context} {
     player_names = context.get_player_names();
   }
-
   /**
    * Accumulate statistics from a batch of game::PositionEvent. Statistics are
    * computed as following: 0) Let B be the ball position before calling
@@ -64,19 +62,16 @@ public:
    */
   void accumulate_stats(std::vector<PositionEvent> const &batch,
                         bool period_last_batch = false);
-
   /**
    * @return the accumulated statistics for the current period, for each player.
    *         Each value is percentage of ball possession for a given player in
    *         the current time units slot.
    */
   std::unordered_map<std::string, double> accumulated_stats() const;
-
   /**
    * @return the last computed partial statistics.
    */
   std::unordered_map<std::string, double> const &last_partial() const;
-
   /**
    * @return the computed ball possession statistics of the whole game, for each
    *         player. Each value is the percentage of ball possession for a given

--- a/include/metadata.hpp
+++ b/include/metadata.hpp
@@ -28,7 +28,6 @@ public:
    * @param player The player wearing the sensor identified by @p sensor_id.
    */
   void add_sensor(int sensor_id, std::string const &player);
-
   /**
    * @brief Checks if a sensor is registered as worn by a player.
    *
@@ -37,7 +36,6 @@ public:
    *         false otherwise.
    */
   bool is_player(int sensor_id) const;
-
   /**
    * @brief Get the player wearing the passed sensor (if any).
    *
@@ -47,12 +45,10 @@ public:
    *         sensor_id.
    */
   std::string const &operator[](int const &sensor_id) const;
-
   /**
    * @return the list of all player names.
    */
   std::vector<std::string> get_player_names() const;
-
   /**
    * @param name The player name.
    * @return the list of sensor ids attached to player @p name.
@@ -85,7 +81,6 @@ public:
    * @param team The team the player plays in.
    */
   void add_player(std::string const &player, Team team);
-
   /**
    * Get the team of a player (if registered).
    *
@@ -113,7 +108,6 @@ public:
    *         false otherwise.
    */
   bool is_ball(int sensor_id) const;
-
   /**
    * @brief Register that a sensor is wrapped by a ball.
    *
@@ -173,7 +167,6 @@ private:
  * @return The game metadata.
  */
 Metadata parse_metadata_file(std::string const &path);
-
 /**
  * Parses metadata from a string.
  * @param path The metadata string.

--- a/include/position.hpp
+++ b/include/position.hpp
@@ -27,13 +27,11 @@ public:
   std::tuple<double, double, double> vector() const {
     return static_cast<Derived &>(*this).vector();
   }
-
   /**
    * Add a sensor to this entity to track.
    * @param sid The sensor id.
    */
   void add_sensor(int sid) { static_cast<Derived &>(*this).add_sensor(sid); }
-
   /**
    * Updates the position of a sensor
    * @param sid The sensor id which position to update.
@@ -42,7 +40,6 @@ public:
   void update_sensor(int sid, std::tuple<int, int, int> vector) {
     static_cast<Derived &>(*this).update_sensor(sid, vector);
   }
-
   /**
    * @return the list of sensor ids attached to this entity.
    */
@@ -64,12 +61,10 @@ public:
    *         A (inf, inf, inf) vector in case no ball is on the field.
    */
   std::tuple<double, double, double> vector() const;
-
   /**
    * Implementation of game::Position::update_sensor().
    */
   void update_sensor(int sid, std::tuple<int, int, int> vector);
-
   /**
    * Implementation of game::Position::add_sensor().
    *
@@ -83,7 +78,6 @@ public:
 
     game_ball = sids.size() - 1; // Set last add ball as the game one
   }
-
   /**
    * Implementation of game::Position::get_sids().
    */
@@ -114,12 +108,10 @@ public:
    * that dimension of the values of each sensor.
    */
   std::tuple<double, double, double> vector() const;
-
   /**
    * Implementation of game::Position::update_sensor().
    */
   void update_sensor(int sid, std::tuple<int, int, int> vector);
-
   /**
    * Implementation of game::Position::add_sensor().
    */
@@ -129,7 +121,6 @@ public:
     ys.push_back(0);
     zs.push_back(0);
   }
-
   /**
    * Implementation of game::Position::get_sids().
    */

--- a/test/test_event_fetcher.cpp
+++ b/test/test_event_fetcher.cpp
@@ -13,11 +13,26 @@
 TEST_CASE("Test Event Fetcher", "[event_fetcher]") {
   using namespace std::literals;
 
-  SECTION("Test dataset event parsing") {
+  SECTION("Test dataset event parsing with Regex") {
     const auto event_line =
         "SE,69,10632029737813340,27679,-221,1011,553570,2481132,-9441,2048,2580,-8913,1107,4396"s;
     auto expected_timestamp = std::chrono::picoseconds{10632029737813340};
-    auto event = game::parse_event_line(event_line);
+    auto event = game::parse_event_line(event_line, game::parser_regex{});
+    REQUIRE(std::holds_alternative<game::PositionEvent>(event));
+
+    auto position_event = std::get<game::PositionEvent>(event);
+    REQUIRE(69 == position_event.get_sid());
+    REQUIRE(expected_timestamp == position_event.get_timestamp());
+    REQUIRE(27679 == position_event.get_x());
+    REQUIRE(-221 == position_event.get_y());
+    REQUIRE(1011 == position_event.get_z());
+  }
+
+  SECTION("Test dataset event parsing with Custom") {
+    const auto event_line =
+        "SE,69,10632029737813340,27679,-221,1011,553570,2481132,-9441,2048,2580,-8913,1107,4396"s;
+    auto expected_timestamp = std::chrono::picoseconds{10632029737813340};
+    auto event = game::parse_event_line(event_line, game::parser_custom{});
     REQUIRE(std::holds_alternative<game::PositionEvent>(event));
 
     auto position_event = std::get<game::PositionEvent>(event);


### PR DESCRIPTION
A new parser for the event lines is implemented which improves the performance dramatically. Previously lines were parsed exploiting a regular expression based parser, which was the bottleneck of the application. The new, custom, one is much faster. Parsing is no longer the bottleneck. Yeah! :)

Signed-off-by: Leonardo Arcari <lippol94@gmail.com>