### PR TITLE
Fix game time bug in Visualizer and improve interface:

### DIFF
--- a/include/batch.hpp
+++ b/include/batch.hpp
@@ -29,9 +29,10 @@ struct Batch {
    * @param snapshot The snapshot of the field.
    */
   Batch(std::vector<PositionEvent> const &data, bool is_period_last_batch,
-        std::unordered_map<std::string, Positions> const &snapshot)
-      : data{std::addressof(data)},
-        is_period_last_batch{is_period_last_batch}, snapshot{snapshot} {}
+        std::unordered_map<std::string, Positions> const &snapshot,
+        std::chrono::picoseconds initial_ts, std::chrono::picoseconds final_ts)
+      : data{std::addressof(data)}, is_period_last_batch{is_period_last_batch},
+        snapshot{snapshot}, initial_ts{initial_ts}, final_ts{final_ts} {}
   /**
    * Construct a new Batch.
    * @param data The input batch of PositionEvents
@@ -40,9 +41,17 @@ struct Batch {
    * @param snapshot The snapshot of the field.
    */
   Batch(std::vector<PositionEvent> const &data, bool is_period_last_batch,
-        std::unordered_map<std::string, Positions> &&snapshot)
+        std::unordered_map<std::string, Positions> &&snapshot,
+        std::chrono::picoseconds initial_ts, std::chrono::picoseconds final_ts)
       : data{std::addressof(data)}, is_period_last_batch{is_period_last_batch},
-        snapshot{std::move(snapshot)} {}
+        snapshot{std::move(snapshot)}, initial_ts{initial_ts}, final_ts{
+                                                                   final_ts} {}
+  /**
+   * @return the time interval between first and last event in the batch
+   */
+  std::chrono::picoseconds get_interval() const {
+    return final_ts - initial_ts;
+  }
   /**
    * The input batch of PositionEvents
    */
@@ -56,6 +65,8 @@ struct Batch {
    * The snapshot of the field.
    */
   Snapshot snapshot = {};
+  std::chrono::picoseconds initial_ts = {};
+  std::chrono::picoseconds final_ts = {};
 };
 } // namespace game
 

--- a/include/event_fetcher.hpp
+++ b/include/event_fetcher.hpp
@@ -96,6 +96,7 @@ private:
   Snapshot snapshot;
   int time_units = 0;
   std::chrono::picoseconds period_start;
+  std::chrono::picoseconds last_in_game_ts = game_start;
   std::size_t batch_size = 0;
 
   bool is_period_over(PositionEvent const &event);
@@ -103,6 +104,7 @@ private:
   Batch batch_game_paused(PositionEvent const &event);
   Batch batch_game_break(PositionEvent const &event);
   Batch batch_game_over();
+  Batch batch_full_size();
   void add_event_to_batch(PositionEvent const &event);
   void update_sensor_position(PositionEvent const &event);
 };

--- a/include/visualizer.hpp
+++ b/include/visualizer.hpp
@@ -21,8 +21,12 @@ public:
   virtual ~Visualizer();
 
   void draw();
+  void draw_stats(std::unordered_map<std::string, double> const &partial,
+                  bool is_game_end, std::chrono::picoseconds last_ts);
+  void
+  draw_final_stats(std::unordered_map<std::string, double> const &game_stats);
   void update_stats(std::unordered_map<std::string, double> const &partial,
-                    bool is_game_end = false);
+                    bool is_game_end, std::chrono::picoseconds last_ts);
 
 private:
   std::ostream *os;

--- a/src/soccer_monitoring.cpp
+++ b/src/soccer_monitoring.cpp
@@ -38,15 +38,12 @@ void run_game_monitoring(int time_units, double maximum_distance,
                  "seconds\n",
                  time_units, time_units * 1500, diff.count());
       t1 = t2;
-      visualizer.update_stats(partials);
-      visualizer.draw();
+      visualizer.draw_stats(partials, false, batch.final_ts);
     }
   }
 
-  fmt::print("-------- Game End. Final Statistics ---------\n\n");
   auto game_stats = stats.game_stats();
-  visualizer.update_stats(game_stats, true);
-  visualizer.draw();
+  visualizer.draw_final_stats(game_stats);
 }
 
 void run_game_monitoring(int time_units, double maximum_distance,
@@ -64,20 +61,26 @@ void run_game_monitoring(int time_units, double maximum_distance,
                                     time_units, batch_size, context};
   auto stats = game::GameStatistics{maximum_distance, context};
 
+  visualizer.draw();
+  auto t1 = std::chrono::steady_clock::now();
   for (auto const &batch : fetcher) {
     // Check if batch returned because time_units seconds are elapsed
     stats.accumulate_stats(batch);
 
     if (batch.is_period_last_batch) {
       auto const &partials = stats.last_partial();
-      visualizer.update_stats(partials);
-      visualizer.draw();
+
+      auto t2 = std::chrono::steady_clock::now();
+      std::chrono::duration<double> diff = t2 - t1;
+      fmt::print("Processed {} seconds of the stream (~ {} events) in {:.3f} "
+                 "seconds\n",
+                 time_units, time_units * 1500, diff.count());
+      t1 = t2;
+      visualizer.draw_stats(partials, false, batch.final_ts);
     }
   }
 
-  fmt::print("-------- Game End. Final Statistics ---------\n\n");
   auto game_stats = stats.game_stats();
-  visualizer.update_stats(game_stats, true);
-  visualizer.draw();
+  visualizer.draw_final_stats(game_stats);
 }
 } // namespace game

--- a/test/test_visualizer.cpp
+++ b/test/test_visualizer.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Test Visualizer") {
     for (auto const &batch : fetcher) {
       stats.accumulate_stats(batch);
       auto partials = stats.accumulated_stats();
-      visualizer.update_stats(partials);
+      visualizer.update_stats(partials, false, batch.final_ts);
       visualizer.draw();
     }
   }


### PR DESCRIPTION
This commit fixes a bug in Visualizer that made game time printing wrong.
Moreover it extends the Visualizer interface introducing 2 methods to update and immediately draw partials and whole-game statistics.

Signed-off-by: Leonardo Arcari <lippol94@gmail.com>